### PR TITLE
Aggregate all QA tool fixes

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,3 +1,2 @@
 coverage_clover: clover.xml
 json_path: coveralls-upload.json
-src_dir: src

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,12 +31,12 @@ matrix:
     - php: 5.6
       env:
         - DEPS=locked
-        - TEST_COVERAGE=true
         - DEPLOY_DOCS="$(if [[ $TRAVIS_BRANCH == 'master' && $TRAVIS_PULL_REQUEST == 'false' ]]; then echo -n 'true' ; else echo -n 'false' ; fi)"
         - PATH="$HOME/.local/bin:$PATH"
     - php: 5.6
       env:
         - DEPS=latest
+        - TEST_COVERAGE=true
     - php: 7
       env:
         - DEPS=lowest

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ env:
     - secure: "LLQyY02oKjXOsoU++VOH9HPfKTunYZlMfPkHwLFPHBNop8TMWznKCJPokQVvN3sdQt/vFycKIJ22stIMnQ0w2C8KoZ+UJBWg4VwQSYbqJbPs4NV6zqPYhPuUwdZxmdFXo9kW4ZP6/HQgSIHEEguzcu/1EFtJDLZzFE8zxPctT7So1yZ0HZJFg/sYKg1fYN2PhYQ+2a8WiucuuixLv0qUFjf8eYzqMBse4r1r9CpibgeLuHGQctLkJtedbTbVdbHBusyNY2T6n02RnTjOkiFYJOMxl9DCELEz3hxhF1b6oasmu0N2B1Jdyux61nLvJwDhcILxbDxPUDx6xyqDjAYUvqHOaVC4V+9Ie3wK6u21xeiYqmJIkECZV5I9h8DYdufU37V5XO3zv++6gGMIJGaGPLu2kHdfKuwdGgQryRWkT71/nlR3H8W4YV6V4IWb+zl5zKfM847D4yadjwTm0B8Ko2zMWc5O4FdetltM4H83jWfX4nIgdnvlgHp9oWe+Z9+VTlpuuoHtvWM+EYmlqhLgpFEoc75CszU1PDO809TjvZVb7Gm2LQqir2r1us2H5hna35116G3hN9yn2XZ4xGWaoXh0PoSqnys9T/jUqlohqXnGKKb0aJR+K1y+2rb/EeovJPLTXCv4FTyiisCl4MDFdgE8OGc7YTeAsl2ohapN0TQ="
 
 matrix:
-  fast_finish: true
   include:
     - php: 5.6
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,7 @@ before_install:
 install:
   - if [[ $DEPS == 'latest' ]]; then travis_retry composer update $COMPOSER_ARGS ; fi
   - if [[ $DEPS == 'lowest' ]]; then travis_retry composer update --prefer-lowest --prefer-stable $COMPOSER_ARGS ; fi
-  - if [[ $TEST_COVERAGE == 'true' ]]; then travis_retry composer require --dev $COMPOSER_ARGS satooshi/php-coveralls ; fi
+  - if [[ $TEST_COVERAGE == 'true' ]]; then travis_retry composer require --dev $COMPOSER_ARGS satooshi/php-coveralls:^1.0 ; fi
   - travis_retry composer install $COMPOSER_ARGS
   - composer show --installed
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,7 @@ before_install:
 install:
   - if [[ $DEPS == 'latest' ]]; then travis_retry composer update $COMPOSER_ARGS ; fi
   - if [[ $DEPS == 'lowest' ]]; then travis_retry composer update --prefer-lowest --prefer-stable $COMPOSER_ARGS ; fi
-  - if [[ $TEST_COVERAGE == 'true' ]]; then travis_retry composer require --no-update --dev $COMPOSER_ARGS satooshi/php-coveralls ; fi
+  - if [[ $TEST_COVERAGE == 'true' ]]; then travis_retry composer require --dev $COMPOSER_ARGS satooshi/php-coveralls ; fi
   - travis_retry composer install $COMPOSER_ARGS
   - composer show --installed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,24 +77,24 @@ To do so:
 
 ## Running Coding Standards Checks
 
-This component uses [php-cs-fixer](http://cs.sensiolabs.org/) for coding
+This component uses [phpcs](https://github.com/squizlabs/PHP_CodeSniffer) for coding
 standards checks, and provides configuration for our selected checks.
-`php-cs-fixer` is installed by default via Composer.
+`phpcs` is installed by default via Composer.
 
 To run checks only:
 
 ```console
-$ ./vendor/bin/php-cs-fixer fix . -v --diff --dry-run --config-file=.php_cs
+$ ./vendor/bin/phpcs
 ```
 
-To have `php-cs-fixer` attempt to fix problems for you, omit the `--dry-run`
-flag:
+`phpcs` also includes a tool for fixing most CS violations, `phpcbf`:
+
 
 ```console
-$ ./vendor/bin/php-cs-fixer fix . -v --diff --config-file=.php_cs
+$ ./vendor/bin/phpcbf
 ```
 
-If you allow php-cs-fixer to fix CS issues, please re-run the tests to ensure
+If you allow `phpcbf` to fix CS issues, please re-run the tests to ensure
 they pass, and make sure you add and commit the changes after verification.
 
 ## Recommended Workflow for Contributions

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,14 +84,14 @@ standards checks, and provides configuration for our selected checks.
 To run checks only:
 
 ```console
-$ ./vendor/bin/phpcs
+$ composer cs-check
 ```
 
 `phpcs` also includes a tool for fixing most CS violations, `phpcbf`:
 
 
 ```console
-$ ./vendor/bin/phpcbf
+$ composer cs-fix
 ```
 
 If you allow `phpcbf` to fix CS issues, please re-run the tests to ensure

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
         "zendframework/zend-servicemanager": "^3.0.3"
     },
     "require-dev": {
-        "squizlabs/php_codesniffer": "^2.3.1",
-        "phpunit/phpunit": "^4.5"
+        "phpunit/phpunit": "^4.5",
+        "zendframework/zend-coding-standard": "~1.0.0"
     },
     "conflict": {
         "zendframework/zend-servicemanager": "<3.0"

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
             "@cs-check",
             "@test"
         ],
-        "upload-coverage": "coveralls",
+        "upload-coverage": "coveralls -v",
         "cs-check": "phpcs",
         "cs-fix": "phpcbf fix -v",
         "test": "phpunit",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "6fcb05ffb27c77c85efd5d401e8ecce7",
-    "content-hash": "b2209b5cd2d778ec9312f85eb993e265",
+    "hash": "581fae954fe8f4252f3cba1d2b1b7c65",
+    "content-hash": "2fc8173ac7bb698f65f67b854b500d61",
     "packages": [
         {
             "name": "container-interop/container-interop",
@@ -1296,16 +1296,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "2.6.1",
+            "version": "2.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "fb72ed32f8418db5e7770be1653e62e0d6f5dd3d"
+                "reference": "571e27b6348e5b3a637b2abc82ac0d01e6d7bbed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/fb72ed32f8418db5e7770be1653e62e0d6f5dd3d",
-                "reference": "fb72ed32f8418db5e7770be1653e62e0d6f5dd3d",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/571e27b6348e5b3a637b2abc82ac0d01e6d7bbed",
+                "reference": "571e27b6348e5b3a637b2abc82ac0d01e6d7bbed",
                 "shasum": ""
             },
             "require": {
@@ -1370,7 +1370,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2016-05-30 22:24:32"
+            "time": "2016-09-01 23:53:02"
         },
         {
             "name": "symfony/yaml",
@@ -1469,6 +1469,35 @@
                 "validate"
             ],
             "time": "2015-08-24 13:29:44"
+        },
+        {
+            "name": "zendframework/zend-coding-standard",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-coding-standard.git",
+                "reference": "893316d2904e93f1c74c1384b6d7d57778299cb6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-coding-standard/zipball/893316d2904e93f1c74c1384b6d7d57778299cb6",
+                "reference": "893316d2904e93f1c74c1384b6d7d57778299cb6",
+                "shasum": ""
+            },
+            "require": {
+                "squizlabs/php_codesniffer": "^2.7"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Zend Framework coding standard",
+            "keywords": [
+                "Coding Standard",
+                "zf"
+            ],
+            "time": "2016-11-09 21:30:43"
         }
     ],
     "aliases": [],

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,19 +1,6 @@
 <?xml version="1.0"?>
 <ruleset name="Zend Framework coding standard">
-    <description>Zend Framework coding standard</description>
-
-    <!-- display progress -->
-    <arg value="p"/>
-    <arg name="colors"/>
-
-    <!-- inherit rules from: -->
-    <rule ref="PSR2"/>
-    <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>
-    <rule ref="Squiz.WhiteSpace.SuperfluousWhitespace">
-        <properties>
-            <property name="ignoreBlankLines" value="false"/>
-        </properties>
-    </rule>
+    <rule ref="./vendor/zendframework/zend-coding-standard/ruleset.xml"/>
 
     <!-- Paths to check -->
     <file>src</file>


### PR DESCRIPTION
This patch aggregates #2, #7, and #8, and adds a few other changes to the Travis configuration:

- Tests against PHP 7.1
- Tests against 7.2 (not required for success)
- Removes documentation build support (no longer needed)
- Updates composer installation strategy to be consistent with other repos